### PR TITLE
added error message when no polygon layers provided

### DIFF
--- a/src/common/store/response.store.js
+++ b/src/common/store/response.store.js
@@ -142,6 +142,10 @@ export const useResponseStore = create((set, get) => ({
             drawing.textLayers.forEach(name => textLayerNames.add(name));
           });
 
+          if (polygonLayerNames.size === 0) {
+            throw new Error(i18next.t('error.no.polygonLayerNames'));
+          }
+
           useGeometryStore.getState().updateAnchorPoint({
             coordinates: parsed.anchorPoint,
           });

--- a/src/common/translations/en.js
+++ b/src/common/translations/en.js
@@ -32,6 +32,7 @@ const en = {
     'error.layer.name.contains.illegal.characters': 'Feature class name contains restricted characters.',
     'error.layer.name.not.allowed': 'Restricted name. Please choose something else.',
     'error.layer.name.should.begin.with.letter': 'Feature class name should begin with a letter.',
+    'error.no.polygonLayerNames': 'DWG file(s) submitted must include a closed polygon entity representing the floor exterior.',
     'error.ordinal.not.valid': 'The value must be a valid number between –1000 and 1000.',
     'error.prop.name.cannot.be.empty': 'Property name can not be empty.',
     'error.prop.name.must.be.unique': 'Property name must be unique.',


### PR DESCRIPTION
It should throw an error when DWG file with no polygon layers was uploaded.

Related ticket https://dev.azure.com/msazure/One/_workitems/edit/16899319