### PR TITLE
number input fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ For client<->server communication we use only two requests:
 There is also `fetchAddress` request to public API to search coordinates by address.
 
 All API requests live in `src/common/api/index.js`.
+API is designed to be used only by the onboarding tool and is not supported for any other use.
 
 ## Map interactions.
 

--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -1,3 +1,4 @@
+// The following API is designed to be used only by the onboarding tool and is not supported for any other use.
 import { CONSTANTS } from 'common';
 
 export const HTTP_STATUS_CODE = {

--- a/src/components/number-input/number-input.js
+++ b/src/components/number-input/number-input.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { inputStyles, inputStylesCentered } from './number-input.style';
 
-const allowedKeys = ['Digit0', 'Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6', 'Digit7', 'Digit8', 'Digit9', 'Minus', 'Period'];
+const allowedKeys = '0123456789-.';
 const enterKeyCode = 'Enter';
 const decimalNumber = /^-?\d{1,}(\.\d{0,})?$/;
 
@@ -21,7 +21,18 @@ const NumberInput = ({ value, onChange, placeholder, onSubmit, max, min, classNa
   }, [value]); // eslint-disable-line react-hooks/exhaustive-deps -- only want this effect to run when value changes
 
   const updateStringValue = useCallback((e) => {
-    const value = e.target.value;
+    let value = e.target.value[0] === '+' ? e.target.value.substring(1) : e.target.value;
+    const numberOfDots = value.split('.').length - 1;
+
+    if (numberOfDots > 1) {
+      return;
+    }
+    if (precision && numberOfDots === 1) {
+      const dotPosition = value.indexOf('.');
+      if (value.length > dotPosition + precision + 1) {
+        value = value.substring(0, dotPosition + precision + 1);
+      }
+    }
 
     if (value === '' || (value === '-' && !positiveOnly)) {
       setStringVal(value);
@@ -50,7 +61,7 @@ const NumberInput = ({ value, onChange, placeholder, onSubmit, max, min, classNa
     if (e.code === enterKeyCode && onSubmit) {
       onSubmit(e);
     }
-    if (!allowedKeys.includes(e.code)) {
+    if (!allowedKeys.includes(e.key)) {
       e.preventDefault();
     }
   }, [onSubmit]);

--- a/src/components/number-input/number-input.test.js
+++ b/src/components/number-input/number-input.test.js
@@ -10,6 +10,7 @@ const defaultProps = {
   max: 150,
   min: 50,
   className: 'qwe',
+  precision: 8,
 };
 
 describe('Number input component', () => {
@@ -44,5 +45,41 @@ describe('Number input component', () => {
       },
     });
     expect(defaultProps.onChange).not.toHaveBeenCalled();
+  });
+
+  it('should allow value with leading plus', () => {
+    render(<NumberInput {...defaultProps} />);
+    const input = screen.getByPlaceholderText(defaultProps.placeholder);
+    fireEvent.change(input, {
+      target: {
+        value: '+111',
+      },
+    });
+    expect(defaultProps.onChange).toHaveBeenLastCalledWith(111);
+  });
+
+  it('should allow value with many decimals and truncate if needed', () => {
+    render(<NumberInput {...defaultProps} />);
+    const input = screen.getByPlaceholderText(defaultProps.placeholder);
+    fireEvent.change(input, {
+      target: {
+        value: '55.123456789',
+      },
+    });
+    expect(defaultProps.onChange).toHaveBeenLastCalledWith(55.12345678);
+
+    fireEvent.change(input, {
+      target: {
+        value: '55.756192864197834619823746114916348971623498',
+      },
+    });
+    expect(defaultProps.onChange).toHaveBeenLastCalledWith(55.75619286);
+
+    fireEvent.change(input, {
+      target: {
+        value: '55.1234',
+      },
+    });
+    expect(defaultProps.onChange).toHaveBeenLastCalledWith(55.1234);
   });
 });


### PR DESCRIPTION
- cannot past past 8 decimals. while this is a very, very small value, a user who copies the lat/lon from g-maps for MS Headquarters will not be able to paste it. I think it is ok to accept the paste and truncate at 8 decimals.
- while at it, accept a paste with a leading + and remove it in the text rather than failing the paste: "+45.21" is a valid coordinate
- the fields do not accept input for the num pad