### PR TITLE
fixed bug with old manifest json versions

### DIFF
--- a/src/common/store/layers.store.js
+++ b/src/common/store/layers.store.js
@@ -24,7 +24,11 @@ export const useLayersStore = create(
       polygonLayerNames: polygonLayerNames.sort((a, b) => a.localeCompare(b)),
       textLayerNames: textLayerNames.sort((a, b) => a.localeCompare(b)),
     })),
-    setLayerFromManifestJson: (layers = {}) => {
+    setLayerFromManifestJson: (layers = []) => {
+      if (!checkIfLayersValid(layers)) {
+        return;
+      }
+
       const convertedLayers = convertLayersFromManifestJson(
         layers,
         get().textLayerNames,
@@ -209,6 +213,25 @@ export const useLayersStore = create(
     },
   }),
 );
+
+export function checkIfLayersValid(layers) {
+  if (!Array.isArray(layers)) {
+    return false;
+  }
+  return layers.every((layer) => {
+    if (typeof layer.featureClassName !== 'string' || !Array.isArray(layer.dwgLayers)) {
+      return false;
+    }
+    if (!Array.isArray(layer.featureClassProperties) && layer.featureClassProperties !== undefined) {
+      return false;
+    }
+    if (Array.isArray(layer.featureClassProperties)
+      && !layer.featureClassProperties.every((prop) => typeof prop.featureClassPropertyName === 'string' && Array.isArray(prop.dwgLayers))) {
+      return false;
+    }
+    return true;
+  });
+}
 
 export function getDefaultState() {
   return {

--- a/src/common/store/layers.store.test.js
+++ b/src/common/store/layers.store.test.js
@@ -1,4 +1,9 @@
-import { truncateCoordinates, convertLayersFromManifestJson, getDefaultState } from './layers.store';
+import {
+  truncateCoordinates,
+  convertLayersFromManifestJson,
+  getDefaultState,
+  checkIfLayersValid,
+} from './layers.store';
 import { polygonLayers, polygonLayersWithTruncatedCoordinates, layers } from './layers.store.mock';
 
 describe('layers store', () => {
@@ -34,5 +39,56 @@ describe('layers store', () => {
         value: [],
       }],
     });
+  });
+});
+
+describe('checkIfLayersValid', () => {
+  it('should return false layers is not an array', () => {
+    expect(checkIfLayersValid(1)).toBe(false);
+    expect(checkIfLayersValid('qwe')).toBe(false);
+    expect(checkIfLayersValid({})).toBe(false);
+    expect(checkIfLayersValid(null)).toBe(false);
+    expect(checkIfLayersValid(undefined)).toBe(false);
+    expect(checkIfLayersValid(Infinity)).toBe(false);
+    expect(checkIfLayersValid(NaN)).toBe(false);
+    expect(checkIfLayersValid(new Set())).toBe(false);
+    expect(checkIfLayersValid(new Map())).toBe(false);
+  });
+
+  it('should return false when layers contains invalid data', () => {
+    expect(checkIfLayersValid([{foo: 'bar'}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 123, dwgLayers: []}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: {}}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name'}])).toBe(false);
+    expect(checkIfLayersValid([{dwgLayers: []}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: 1}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: {}}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: null}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: new Set()}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: [{
+        featureClassPropertyName: 1,
+        dwgLayers: [],
+      }]}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: [{
+        featureClassPropertyName: 'name',
+        dwgLayers: new Set(),
+      }]}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: [{
+        featureClassPropertyName: 'name',
+        dwgLayers: null,
+      }]}])).toBe(false);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: [{
+        featureClassPropertyName: null,
+        dwgLayers: [],
+      }]}])).toBe(false);
+  });
+
+  it('should return true when layers is valid', () => {
+    expect(checkIfLayersValid([])).toBe(true);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: []}])).toBe(true);
+    expect(checkIfLayersValid([{featureClassName: 'name', dwgLayers: [], featureClassProperties: [{
+        featureClassPropertyName: 'qwe',
+        dwgLayers: [],
+      }]}])).toBe(true);
   });
 });

--- a/src/common/store/levels.store.js
+++ b/src/common/store/levels.store.js
@@ -23,7 +23,8 @@ export const useLevelsStore = create((set, get) => ({
     }))
   }),
   updateLevels: (levels = []) => {
-    const levelsByFilename = levels.reduce((acc, val) => ({
+    const levelsByFilename = levels.filter((level) => typeof level === 'object' && level !== null)
+      .reduce((acc, val) => ({
       ...acc,
       [val.filename]: val,
     }), {});
@@ -35,9 +36,9 @@ export const useLevelsStore = create((set, get) => ({
         }
         return {
           filename: level.filename,
-          levelName: typeof levelsByFilename[level.filename].levelName === 'string' ? levelsByFilename[level.filename].levelName : '',
-          ordinal: typeof levelsByFilename[level.filename].ordinal === 'number' ? levelsByFilename[level.filename].ordinal.toString() : '',
-          verticalExtent: typeof levelsByFilename[level.filename].verticalExtent === 'number' ? levelsByFilename[level.filename].verticalExtent.toString() : '',
+          levelName: typeof levelsByFilename[level.filename].levelName === 'string' ? levelsByFilename[level.filename].levelName : level.levelName,
+          ordinal: typeof levelsByFilename[level.filename].ordinal === 'number' ? levelsByFilename[level.filename].ordinal.toString() : level.ordinal,
+          verticalExtent: typeof levelsByFilename[level.filename].verticalExtent === 'number' ? levelsByFilename[level.filename].verticalExtent.toString() : level.verticalExtent,
         };
       })
     }));

--- a/src/common/store/progress-bar-steps.js
+++ b/src/common/store/progress-bar-steps.js
@@ -30,12 +30,26 @@ export const progressBarSteps = [
 ];
 
 export const useProgressBarStore = create((set) => ({
-    isErrorShown: false,
-    showError: () => set({
-        isErrorShown: true,
+    isMissingDataErrorShown: false,
+    isIncorrectManifestVersionErrorShown: false,
+    isInvalidManifestErrorShown: false,
+    showIncorrectManifestVersionError: () => set({
+        isIncorrectManifestVersionErrorShown: true,
     }),
-    hideError: () => set({
-        isErrorShown: false,
+    hideIncorrectManifestVersionError: () => set({
+        isIncorrectManifestVersionErrorShown: false,
+    }),
+    showInvalidManifestError: () => set({
+        isInvalidManifestErrorShown: true,
+    }),
+    hideInvalidManifestError: () => set({
+        isInvalidManifestErrorShown: false,
+    }),
+    showMissingDataError: () => set({
+        isMissingDataErrorShown: true,
+    }),
+    hideMissingDataError: () => set({
+        isMissingDataErrorShown: false,
     }),
 }));
 

--- a/src/common/store/response.store.test.js
+++ b/src/common/store/response.store.test.js
@@ -1,7 +1,7 @@
 import { errorResponseMock } from './response.store.mock';
-import { getFirstMeaningfulError } from './response.store';
+import { getFirstMeaningfulError, parseManifestJson } from './response.store';
 
-describe('Response Store', () => {
+describe('getFirstMeaningfulError', () => {
   it('should return first meaningful error', () => {
     const error = getFirstMeaningfulError(errorResponseMock);
     expect(error.code).toEqual('dwgError');
@@ -20,5 +20,73 @@ describe('Response Store', () => {
     const error = getFirstMeaningfulError(errorResponseMock);
     expect(error.code).toEqual('invalidArchiveFormat');
     expect(error.message).toEqual(errorResponseMock.error.details[0].details[0].message);
+  });
+});
+
+describe('parseManifestJson', () => {
+  const validJson = {
+    facilityName: '',
+    buildingLevels: {
+      dwgLayers: [],
+      levels: [],
+    },
+    featureClasses: [],
+    georeference: {
+      lat: 1,
+      lon: 2,
+      angle: 3,
+    }
+  };
+
+  it('should return null when json is not valid', () => {
+    expect(parseManifestJson(null)).toBe(null);
+    expect(parseManifestJson(undefined)).toBe(null);
+    expect(parseManifestJson(NaN)).toBe(null);
+    expect(parseManifestJson(Infinity)).toBe(null);
+    expect(parseManifestJson('')).toBe(null);
+    expect(parseManifestJson()).toBe(null);
+    expect(parseManifestJson([])).toBe(null);
+    expect(parseManifestJson(123)).toBe(null);
+    expect(parseManifestJson('123')).toBe(null);
+    expect(parseManifestJson({})).toBe(null);
+    expect(parseManifestJson({
+      ...validJson,
+      facilityName: 123,
+    })).toBe(null);
+    expect(parseManifestJson({
+      ...validJson,
+      buildingLevels: {
+        ...validJson.buildingLevels,
+        dwgLayers: new Set(),
+      }
+    })).toBe(null);
+    expect(parseManifestJson({
+      ...validJson,
+      featureClasses: new Set(),
+    })).toBe(null);
+    expect(parseManifestJson({
+      ...validJson,
+      georeference: {
+        ...validJson.georeference,
+        lat: '1',
+      }
+    })).toBe(null);
+    expect(parseManifestJson({
+      ...validJson,
+      georeference: {
+        ...validJson.georeference,
+        angle: '1',
+      }
+    })).toBe(null);
+  });
+
+  it('should return true when json is valid', () => {
+    expect(parseManifestJson(validJson)).toEqual({
+      dwgLayers: [],
+      facilityName: '',
+      featureClasses: [],
+      georeference: { angle: 3, lat: 1, lon: 2 },
+      levels: [],
+    });
   });
 });

--- a/src/common/translations/en.js
+++ b/src/common/translations/en.js
@@ -34,6 +34,8 @@ const en = {
     'error.layer.name.contains.illegal.characters': 'Feature class name cannot include invalid characters. Valid characters are: lower case characters (a-z), upper case characters (A-Z), numbers (0-9), and underscore character (\'_\').',
     'error.layer.name.not.allowed': 'Reserved feature class name. Please choose a different name.',
     'error.layer.name.should.begin.with.letter': 'Feature class name must begin with an upper case or lower case character.',
+    'error.manifest.incorrect.version': 'Existing manifest provided is not supported. Only manifest version 2.0 or later is supported.',
+    'error.manifest.invalid': 'Existing manifest provided is invalid.',
     'error.no.polygonLayerNames': 'DWG file(s) submitted must include a closed polygon entity representing the floor exterior.',
     'error.ordinal.must.be.unique': 'Ordinal value must be unique.',
     'error.ordinal.not.valid': 'The value must be a valid number between –1000 and 1000.',

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -9,14 +9,14 @@ import { useCompletedSteps, progressBarSteps, useProgressBarStore } from 'common
 import { useReviewManifestStore } from 'common/store/review-manifest.store';
 
 const reviewManifestSelector = (s) => s.showPane;
-const progressBarStoreSelector = (s) => [s.showError, s.hideError];
+const progressBarStoreSelector = (s) => [s.showMissingDataError, s.hideMissingDataError];
 
 export const Footer = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const completedSteps = useCompletedSteps();
-  const [showError, hideError] = useProgressBarStore(progressBarStoreSelector, shallow);
+  const [showMissingDataError, hideMissingDataError] = useProgressBarStore(progressBarStoreSelector, shallow);
   const showReviewManifestPane = useReviewManifestStore(reviewManifestSelector);
   const order = progressBarSteps.findIndex(route => route.href === pathname);
 
@@ -35,12 +35,12 @@ export const Footer = () => {
   }, [navigate, prevScreenLink]);
   const onReview = useCallback(() => {
     if (allStepsCompleted) {
-      hideError();
+      hideMissingDataError();
       showReviewManifestPane();
     } else {
-      showError();
+      showMissingDataError();
     }
-  }, [allStepsCompleted, hideError, showReviewManifestPane, showError]);
+  }, [allStepsCompleted, hideMissingDataError, showReviewManifestPane, showMissingDataError]);
 
   if (order === -1) {
     return null;

--- a/src/components/progress-bar/__snapshots__/progress-bar.test.js.snap
+++ b/src/components/progress-bar/__snapshots__/progress-bar.test.js.snap
@@ -67,6 +67,14 @@ Object {
   "baseElement": .emotion-0 {
   max-width: 31.25rem;
   margin: 0.9375rem 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .emotion-1 {
@@ -199,6 +207,14 @@ Object {
   "container": .emotion-0 {
   max-width: 31.25rem;
   margin: 0.9375rem 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .emotion-1 {

--- a/src/components/progress-bar/progress-bar-icon.js
+++ b/src/components/progress-bar/progress-bar-icon.js
@@ -5,7 +5,7 @@ import { Icon } from '@fluentui/react/lib/Icon';
 import { iconCompletedStyle, iconErrorStyle, iconStyle } from './progress-bar.style';
 import { useProgressBarStore } from 'common/store';
 
-const progressBarSelector = (s) => s.isErrorShown;
+const progressBarSelector = (s) => s.isMissingDataErrorShown;
 
 const ProgressBarIcon = ({isCompletedStep, label}) => {
   const isProgressBarErrorShown = useProgressBarStore(progressBarSelector);

--- a/src/components/progress-bar/progress-bar-icon.test.js
+++ b/src/components/progress-bar/progress-bar-icon.test.js
@@ -6,13 +6,13 @@ import { useProgressBarStore } from 'common/store';
 describe('ProgressBarIcon', () => {
   beforeEach(() => {
     useProgressBarStore.setState({
-      isErrorShown: false,
+      isMissingDataErrorShown: false,
     });
   });
 
   it('should render error icon', () => {
     useProgressBarStore.setState({
-      isErrorShown: true,
+      isMissingDataErrorShown: true,
     });
     const view = render(<ProgressBarIcon label={'foo'} isCompletedStep={false} />);
     expect(view).toMatchSnapshot();

--- a/src/components/progress-bar/progress-bar.js
+++ b/src/components/progress-bar/progress-bar.js
@@ -8,23 +8,37 @@ import { progressBarSteps, useCompletedSteps, useProgressBarStore } from 'common
 import { errorContainer, progressBarContainer } from './progress-bar.style';
 import ProgressBarButton from './progress-bar-button';
 
-const progressBarStoreSelector = (s) => [s.isErrorShown, s.hideError];
+const progressBarStoreSelector = (s) => [
+  s.isIncorrectManifestVersionErrorShown,
+  s.hideIncorrectManifestVersionError,
+  s.isInvalidManifestErrorShown,
+  s.hideInvalidManifestError,
+  s.isMissingDataErrorShown,
+  s.hideMissingDataError,
+];
 
 export const ProgressBar = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const completedSteps = useCompletedSteps();
-  const [isErrorShown, hideError] = useProgressBarStore(progressBarStoreSelector, shallow);
+  const [
+    isIncorrectManifestVersionErrorShown,
+    hideIncorrectManifestVersionError,
+    isInvalidManifestErrorShown,
+    hideInvalidManifestError,
+    isMissingDataErrorShown,
+    hideMissingDataError,
+  ] = useProgressBarStore(progressBarStoreSelector, shallow);
 
   const shouldShowProgressBar = useMemo(() => (
     progressBarSteps.some((step) => step.href === pathname)
   ), [pathname]);
 
   useEffect(() => {
-    if (completedSteps.length === progressBarSteps.length && isErrorShown) {
-      hideError();
+    if (completedSteps.length === progressBarSteps.length && isMissingDataErrorShown) {
+      hideMissingDataError();
     }
-  }, [completedSteps, isErrorShown, hideError]);
+  }, [completedSteps, isMissingDataErrorShown, hideMissingDataError]);
 
   if (!shouldShowProgressBar) {
     return null;
@@ -33,8 +47,18 @@ export const ProgressBar = () => {
   return (
     <>
       <div className={errorContainer}>
-        {isErrorShown && (
-          <MessageBar messageBarType={MessageBarType.error} isMultiline={false}>
+        {isIncorrectManifestVersionErrorShown && (
+          <MessageBar messageBarType={MessageBarType.warning} isMultiline onDismiss={hideIncorrectManifestVersionError}>
+            {t('error.manifest.incorrect.version')}
+          </MessageBar>
+        )}
+        {isInvalidManifestErrorShown && (
+          <MessageBar messageBarType={MessageBarType.warning} isMultiline onDismiss={hideInvalidManifestError}>
+            {t('error.manifest.invalid')}
+          </MessageBar>
+        )}
+        {isMissingDataErrorShown && (
+          <MessageBar messageBarType={MessageBarType.error} isMultiline>
             {t('error.validation.failed.missing.info')}
           </MessageBar>
         )}

--- a/src/components/progress-bar/progress-bar.style.js
+++ b/src/components/progress-bar/progress-bar.style.js
@@ -5,6 +5,9 @@ import { color, fontSize, fontWeight } from 'common/styles';
 export const errorContainer = css`
   max-width: 31.25rem;
   margin: 0.9375rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 `;
 
 export const progressBarContainer = css`

--- a/src/pages/layers/layer.test.js
+++ b/src/pages/layers/layer.test.js
@@ -30,7 +30,7 @@ describe('Layer component', () => {
       layers: [layer1, layer2],
     });
     useProgressBarStore.setState({
-      isErrorShown: false,
+      isMissingDataErrorShown: false,
     });
   });
 
@@ -62,7 +62,7 @@ describe('Layer component', () => {
 
   it('should show error', () => {
     useProgressBarStore.setState({
-      isErrorShown: true,
+      isMissingDataErrorShown: true,
     });
 
     const view = render(

--- a/src/pages/levels/level.js
+++ b/src/pages/levels/level.js
@@ -10,7 +10,7 @@ import FieldError from 'components/field-error';
 import { fieldLabel, fieldsRow, fileContainer, inputClass, inputStyles, readOnlyInput } from './levels.style';
 
 const levelsSelector = (s) => [s.getOrdinalError, s.levels, s.setOrdinal, s.setLevelName, s.isLevelNameValid, s.setVerticalExtent, s.getVerticalExtentError, s.isOrdinalEmpty];
-const progressBarSelector = (s) => s.isErrorShown;
+const progressBarSelector = (s) => s.isMissingDataErrorShown;
 
 const Level = ({ level }) => {
   const { t } = useTranslation();

--- a/src/pages/levels/level.test.js
+++ b/src/pages/levels/level.test.js
@@ -12,7 +12,7 @@ const mockLevel = {
 describe('Level component', () => {
   beforeEach(() => {
     useProgressBarStore.setState({
-      isErrorShown: false,
+      isMissingDataErrorShown: false,
     });
   });
 
@@ -24,7 +24,7 @@ describe('Level component', () => {
   it('should show error', () => {
     const emptyLevel = { filename: 'kitchen.dwg', levelName: '', ordinal: '' };
     useProgressBarStore.setState({
-      isErrorShown: true,
+      isMissingDataErrorShown: true,
     });
 
     const view = render(<Level level={emptyLevel} />);


### PR DESCRIPTION
current behavior:
- when loading invalid manifest.json (eg of older version) if fails with ugly js error, like 'Object.map is not a function'

new behavior:
- in the same situation now it doesn't fail, but lets user proceed and shows a warning that attached manifest.json file was invalid

Related ticket: https://msazure.visualstudio.com/One/_workitems/edit/17573867

![image](https://user-images.githubusercontent.com/2423760/225928639-9ea90170-317d-4f33-b543-2d35264d765d.png)
