### PR TITLE
fixed a bug with missing coordinates

### DIFF
--- a/src/common/store/response.store.js
+++ b/src/common/store/response.store.js
@@ -141,9 +141,10 @@ export const useResponseStore = create((set, get) => ({
           // drawing = {filename, layer[]}
           // layer = {name, geometry[]}
           parsed.drawings.forEach(drawing => {
+            const validPolygonLayers = drawing.polygonLayers.filter((polygonLayer) => isPolygonLayerComplete(polygonLayer));
             drawing.layers.forEach(layer => layerNames.add(layer));
-            drawing.polygonLayers.forEach(layer => polygonLayerNames.add(layer.name));
-            useLayersStore.getState().addPolygonLayers(drawing.polygonLayers);
+            validPolygonLayers.forEach(layer => polygonLayerNames.add(layer.name));
+            useLayersStore.getState().addPolygonLayers(validPolygonLayers);
             drawing.textLayers.forEach(name => textLayerNames.add(name));
           });
 
@@ -246,4 +247,13 @@ export function getFirstMeaningfulError(data) {
   }
 
   return null;
+}
+
+export function isPolygonLayerComplete(polygonLayer = {}) {
+  if (typeof polygonLayer !== 'object' || polygonLayer === null) {
+    return false;
+  }
+  const { name, geometry } = polygonLayer;
+  return typeof name === 'string' && typeof geometry === 'object' && geometry !== null
+    && typeof geometry.type === 'string' && Array.isArray(geometry.coordinates);
 }

--- a/src/common/store/response.store.test.js
+++ b/src/common/store/response.store.test.js
@@ -1,5 +1,5 @@
 import { errorResponseMock } from './response.store.mock';
-import { getFirstMeaningfulError, parseManifestJson } from './response.store';
+import { getFirstMeaningfulError, isPolygonLayerComplete, parseManifestJson } from './response.store';
 
 describe('getFirstMeaningfulError', () => {
   it('should return first meaningful error', () => {
@@ -89,4 +89,20 @@ describe('parseManifestJson', () => {
       levels: [],
     });
   });
+});
+
+describe('isPolygonLayerComplete', () => {
+  expect(isPolygonLayerComplete({name: 'layer', geometry: { type: 'Polygon', coordinates: []}})).toBe(true);
+  expect(isPolygonLayerComplete({name: 'layer', geometry: { type: 'Polygon', coordinates: {}}})).toBe(false);
+  expect(isPolygonLayerComplete({name: 'layer', geometry: { type: 15, coordinates: []}})).toBe(false);
+  expect(isPolygonLayerComplete({name: 'layer', geometry: { type: 'Polygon'}})).toBe(false);
+  expect(isPolygonLayerComplete({name: undefined, geometry: { type: 'Polygon', coordinates: []}})).toBe(false);
+  expect(isPolygonLayerComplete({name: false, geometry: { type: 'Polygon', coordinates: []}})).toBe(false);
+  expect(isPolygonLayerComplete({name: null, geometry: { type: 'Polygon', coordinates: []}})).toBe(false);
+  expect(isPolygonLayerComplete({geometry: { type: 'Polygon', coordinates: []}})).toBe(false);
+  expect(isPolygonLayerComplete({name: 'layer', geometry: { type: {}, coordinates: []}})).toBe(false);
+  expect(isPolygonLayerComplete()).toBe(false);
+  expect(isPolygonLayerComplete('')).toBe(false);
+  expect(isPolygonLayerComplete(null)).toBe(false);
+  expect(isPolygonLayerComplete(false)).toBe(false);
 });


### PR DESCRIPTION
Some polygonLayers don't have geometry.coordinates prop and this was causing runtime errors on frontend.
This fix just skips broken polygon layers.