### PR TITLE
clean up unfinished conversions

### DIFF
--- a/src/common/api/conversion.js
+++ b/src/common/api/conversion.js
@@ -54,16 +54,19 @@ export const deleteCreatedData = () => {
   if (uploadUdId !== null) {
     fetch(`${getEnvs()[geography].URL}/mapData/${uploadUdId}?api-version=2.0&subscription-key=${subscriptionKey}`, {
       method: 'DELETE',
+      keepalive: true,
     });
   }
   if (conversionId !== null) {
     fetch(`${getEnvs()[geography].URL}/conversions/${conversionId}?api-version=2.0&subscription-key=${subscriptionKey}`, {
       method: 'DELETE',
+      keepalive: true,
     });
   }
   if (datasetId !== null) {
     fetch(`${getEnvs()[geography].URL}/datasets/${datasetId}?api-version=2.0&subscription-key=${subscriptionKey}`, {
       method: 'DELETE',
+      keepalive: true,
     });
   }
 };

--- a/src/common/api/conversion.js
+++ b/src/common/api/conversion.js
@@ -1,5 +1,6 @@
 import { getEnvs } from 'common/functions';
 import { useUserStore } from '../store/user.store';
+import { useConversionStore } from '../store/conversion.store';
 
 const apiVersion = '2.0';
 const previewApiVersion = '2023-03-01-preview';
@@ -41,4 +42,28 @@ export const startTileset = (datasetId) => {
   return fetch(url, {
     method: 'POST',
   });
+};
+
+export const deleteCreatedData = () => {
+  const { geography, subscriptionKey } = useUserStore.getState();
+  const { uploadUdId, conversionId, datasetId, tilesetId } = useConversionStore.getState();
+
+  if (tilesetId !== null) {
+    return;
+  }
+  if (uploadUdId !== null) {
+    fetch(`${getEnvs()[geography].URL}/mapData/${uploadUdId}?api-version=2.0&subscription-key=${subscriptionKey}`, {
+      method: 'DELETE',
+    });
+  }
+  if (conversionId !== null) {
+    fetch(`${getEnvs()[geography].URL}/conversions/${conversionId}?api-version=2.0&subscription-key=${subscriptionKey}`, {
+      method: 'DELETE',
+    });
+  }
+  if (datasetId !== null) {
+    fetch(`${getEnvs()[geography].URL}/datasets/${datasetId}?api-version=2.0&subscription-key=${subscriptionKey}`, {
+      method: 'DELETE',
+    });
+  }
 };

--- a/src/common/api/conversion.test.js
+++ b/src/common/api/conversion.test.js
@@ -50,7 +50,7 @@ describe('conversion api', () => {
     deleteCreatedData();
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/mapData/123?api-version=2.0&subscription-key=subKeeeeeeey',
-      { 'method': 'DELETE' },
+      { 'method': 'DELETE', 'keepalive': true },
     );
   });
 
@@ -62,11 +62,11 @@ describe('conversion api', () => {
     deleteCreatedData();
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/mapData/123?api-version=2.0&subscription-key=subKeeeeeeey',
-      { 'method': 'DELETE' },
+      { 'method': 'DELETE', 'keepalive': true },
     );
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/conversions/234?api-version=2.0&subscription-key=subKeeeeeeey',
-      { 'method': 'DELETE' },
+      { 'method': 'DELETE', 'keepalive': true },
     );
   });
 
@@ -79,15 +79,15 @@ describe('conversion api', () => {
     deleteCreatedData();
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/mapData/123?api-version=2.0&subscription-key=subKeeeeeeey',
-      { 'method': 'DELETE' },
+      { 'method': 'DELETE', 'keepalive': true },
     );
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/conversions/234?api-version=2.0&subscription-key=subKeeeeeeey',
-      { 'method': 'DELETE' },
+      { 'method': 'DELETE', 'keepalive': true },
     );
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/datasets/345?api-version=2.0&subscription-key=subKeeeeeeey',
-      { 'method': 'DELETE' },
+      { 'method': 'DELETE', 'keepalive': true },
     );
   });
 

--- a/src/common/api/conversion.test.js
+++ b/src/common/api/conversion.test.js
@@ -1,4 +1,5 @@
-import { uploadConversion, startConversion, startDataset, startTileset } from './conversion';
+import { uploadConversion, startConversion, startDataset, startTileset, deleteCreatedData } from './conversion';
+import { useConversionStore } from '../store';
 
 jest.mock('../store/user.store', () => ({
   useUserStore: {
@@ -40,5 +41,64 @@ describe('conversion api', () => {
       'https://eu.atlas.microsoft.com/tilesets?api-version=2023-03-01-preview&datasetId=da-ta-set-id&subscription-key=subKeeeeeeey',
       { 'method': 'POST' },
     );
+  });
+
+  it('should delete uploaded data', () => {
+    useConversionStore.setState({
+      uploadUdId: 123,
+    });
+    deleteCreatedData();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://eu.atlas.microsoft.com/mapData/123?api-version=2.0&subscription-key=subKeeeeeeey',
+      { 'method': 'DELETE' },
+    );
+  });
+
+  it('should delete uploaded data and conversion', () => {
+    useConversionStore.setState({
+      uploadUdId: 123,
+      conversionId: 234,
+    });
+    deleteCreatedData();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://eu.atlas.microsoft.com/mapData/123?api-version=2.0&subscription-key=subKeeeeeeey',
+      { 'method': 'DELETE' },
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://eu.atlas.microsoft.com/conversions/234?api-version=2.0&subscription-key=subKeeeeeeey',
+      { 'method': 'DELETE' },
+    );
+  });
+
+  it('should delete uploaded data and conversion and dataset', () => {
+    useConversionStore.setState({
+      uploadUdId: 123,
+      conversionId: 234,
+      datasetId: 345,
+    });
+    deleteCreatedData();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://eu.atlas.microsoft.com/mapData/123?api-version=2.0&subscription-key=subKeeeeeeey',
+      { 'method': 'DELETE' },
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://eu.atlas.microsoft.com/conversions/234?api-version=2.0&subscription-key=subKeeeeeeey',
+      { 'method': 'DELETE' },
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://eu.atlas.microsoft.com/datasets/345?api-version=2.0&subscription-key=subKeeeeeeey',
+      { 'method': 'DELETE' },
+    );
+  });
+
+  it('should delete nothing when tileset id is not null', () => {
+    useConversionStore.setState({
+      uploadUdId: 123,
+      conversionId: 234,
+      datasetId: 345,
+      tilesetId: 456,
+    });
+    deleteCreatedData();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/common/store/conversion.store.js
+++ b/src/common/store/conversion.store.js
@@ -1,6 +1,12 @@
 import { create } from 'zustand';
 
-import { startConversion, startDataset, startTileset, uploadConversion } from 'common/api/conversion';
+import {
+  deleteCreatedData,
+  startConversion,
+  startDataset,
+  startTileset,
+  uploadConversion,
+} from 'common/api/conversion';
 import { fetchFromLocation } from 'common/api';
 import { HTTP_STATUS_CODE } from 'common/constants';
 import { LRO_STATUS } from './response.store';
@@ -67,6 +73,7 @@ export const useConversionStore = create((set, get) => ({
   }),
   uploadPackage: (file) => {
     set({
+      ...getDefaultState(),
       uploadStartTime: Date.now(),
       uploadStepStatus: conversionStatuses.inProgress,
     });
@@ -78,6 +85,7 @@ export const useConversionStore = create((set, get) => ({
             uploadOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             uploadEndTime: Date.now(),
           });
+          deleteCreatedData();
         });
       } else {
         get().fetchUploadStatus(res.headers.get(OPERATION_LOCATION));
@@ -88,9 +96,13 @@ export const useConversionStore = create((set, get) => ({
         uploadOperationLog: e.message || defaultErrorMessage,
         uploadEndTime: Date.now(),
       });
+      deleteCreatedData();
     });
   },
   fetchUploadStatus: (location) => {
+    if (get().uploadStartTime === null) {
+      return;
+    }
     fetchFromLocation(location)
       .then(async (res) => {
         if (res.status !== HTTP_STATUS_CODE.OK) {
@@ -105,6 +117,7 @@ export const useConversionStore = create((set, get) => ({
             uploadOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             uploadEndTime: Date.now(),
           });
+          deleteCreatedData();
         } else if (data.status === LRO_STATUS.RUNNING) {
           set(() => ({
             uploadOperationId: data.operationId,
@@ -138,9 +151,13 @@ export const useConversionStore = create((set, get) => ({
         uploadOperationLog: e.message || defaultErrorMessage,
         uploadEndTime: Date.now(),
       });
+      deleteCreatedData();
     });
   },
   startConversion: (udid) => {
+    if (get().uploadStartTime === null) {
+      return;
+    }
     set({
       conversionStartTime: Date.now(),
       conversionStepStatus: conversionStatuses.inProgress,
@@ -153,6 +170,7 @@ export const useConversionStore = create((set, get) => ({
             conversionOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             conversionEndTime: Date.now(),
           });
+          deleteCreatedData();
         });
       } else {
         get().fetchConversionStatus(res.headers.get(OPERATION_LOCATION));
@@ -163,9 +181,13 @@ export const useConversionStore = create((set, get) => ({
         conversionOperationLog: e.message || defaultErrorMessage,
         conversionEndTime: Date.now(),
       });
+      deleteCreatedData();
     });
   },
   fetchConversionStatus: (operationLocation) => {
+    if (get().uploadStartTime === null) {
+      return;
+    }
     fetchFromLocation(operationLocation)
       .then(async (res) => {
         if (res.status !== HTTP_STATUS_CODE.OK) {
@@ -180,6 +202,7 @@ export const useConversionStore = create((set, get) => ({
             conversionOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             conversionEndTime: Date.now(),
           });
+          deleteCreatedData();
         } else if (data.status === LRO_STATUS.RUNNING) {
           set(() => ({
             conversionOperationId: data.operationId,
@@ -216,9 +239,13 @@ export const useConversionStore = create((set, get) => ({
           conversionOperationLog: e.message || defaultErrorMessage,
           conversionEndTime: Date.now(),
         });
+        deleteCreatedData();
       });
   },
   startDataset: (conversionId) => {
+    if (get().uploadStartTime === null) {
+      return;
+    }
     set({
       datasetStartTime: Date.now(),
       datasetStepStatus: conversionStatuses.inProgress,
@@ -231,6 +258,7 @@ export const useConversionStore = create((set, get) => ({
             datasetOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             datasetEndTime: Date.now(),
           });
+          deleteCreatedData();
         });
       } else {
         get().fetchDatasetStatus(res.headers.get(OPERATION_LOCATION));
@@ -241,9 +269,13 @@ export const useConversionStore = create((set, get) => ({
         datasetOperationLog: e.message || defaultErrorMessage,
         datasetEndTime: Date.now(),
       });
+      deleteCreatedData();
     });
   },
   fetchDatasetStatus: (location) => {
+    if (get().uploadStartTime === null) {
+      return;
+    }
     fetchFromLocation(location)
       .then(async (res) => {
         if (res.status !== HTTP_STATUS_CODE.OK) {
@@ -258,6 +290,7 @@ export const useConversionStore = create((set, get) => ({
             datasetOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             datasetEndTime: Date.now(),
           });
+          deleteCreatedData();
         } else if (data.status === LRO_STATUS.RUNNING) {
           set(() => ({
             datasetOperationId: data.operationId,
@@ -292,9 +325,13 @@ export const useConversionStore = create((set, get) => ({
           datasetOperationLog: e.message || defaultErrorMessage,
           datasetEndTime: Date.now(),
         });
+        deleteCreatedData();
       });
   },
   startTileset: (datasetId) => {
+    if (get().uploadStartTime === null) {
+      return;
+    }
     set({
       tilesetStartTime: Date.now(),
       tilesetStepStatus: conversionStatuses.inProgress,
@@ -307,6 +344,7 @@ export const useConversionStore = create((set, get) => ({
             tilesetOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             tilesetEndTime: Date.now(),
           });
+          deleteCreatedData();
         });
       } else {
         get().fetchTilesetStatus(res.headers.get(OPERATION_LOCATION));
@@ -317,9 +355,13 @@ export const useConversionStore = create((set, get) => ({
         tilesetOperationLog: e.message || defaultErrorMessage,
         tilesetEndTime: Date.now(),
       });
+      deleteCreatedData();
     });
   },
   fetchTilesetStatus: (location) => {
+    if (get().uploadStartTime === null) {
+      return;
+    }
     fetchFromLocation(location)
       .then(async (res) => {
         if (res.status !== HTTP_STATUS_CODE.OK) {
@@ -334,6 +376,7 @@ export const useConversionStore = create((set, get) => ({
             tilesetOperationLog: data.error ? JSON.stringify(data.error, null, 4) : defaultErrorMessage,
             tilesetEndTime: Date.now(),
           });
+          deleteCreatedData();
         } else if (data.status === LRO_STATUS.RUNNING) {
           set(() => ({
             tilesetOperationId: data.operationId,
@@ -369,6 +412,7 @@ export const useConversionStore = create((set, get) => ({
           tilesetOperationLog: e.message || defaultErrorMessage,
           tilesetEndTime: Date.now(),
         });
+        deleteCreatedData();
       });
   },
 }));

--- a/src/components/bread-crumb-nav/bread-crumb-nav.js
+++ b/src/components/bread-crumb-nav/bread-crumb-nav.js
@@ -5,6 +5,8 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { breadcrumbStyle } from './bread-crumb-nav.style';
 import { getSplitPaths } from 'common/functions';
 import { PATHS, ROUTE_NAME_BY_PATH } from 'common/constants';
+import { deleteCreatedData } from 'common/api/conversion';
+import { useConversionStore } from 'common/store';
 
 const routesConfirmationRequiredBeforeLeaving = [
   PATHS.CONVERSION,
@@ -26,6 +28,8 @@ const BreadCrumbNav = () => {
         }
         if (routesConfirmationRequiredBeforeLeaving.includes(pathname)) {
           if (window.confirm(t('progress.will.be.lost'))) {
+            deleteCreatedData();
+            useConversionStore.getState().reset();
             navigate(path);
           }
         } else {

--- a/src/pages/conversion/index.js
+++ b/src/pages/conversion/index.js
@@ -1,5 +1,6 @@
 import { shallow } from 'zustand/shallow';
 import { useTranslation } from 'react-i18next';
+import { useEffect } from 'react';
 
 import { container, content, stepsContainer } from './style';
 import UploadContent from './upload-content';
@@ -8,6 +9,15 @@ import DatasetContent from './dataset-content';
 import TilesetContent from './tileset-content';
 import StepButton from './step-button';
 import { conversionSteps, useConversionStore } from 'common/store';
+import { deleteCreatedData } from 'common/api/conversion';
+
+const unloadCallback = () => {
+  deleteCreatedData();
+};
+const beforeUnload = (e) => {
+  e.preventDefault();
+  return true;
+};
 
 const conversionStoreSelector = (s) => [
   s.uploadStepStatus,
@@ -41,6 +51,15 @@ const Conversion = () => {
     tilesetStartTime,
     tilesetEndTime,
   ] = useConversionStore(conversionStoreSelector, shallow);
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', beforeUnload);
+    window.addEventListener('unload', unloadCallback);
+    return () => {
+      window.removeEventListener('beforeunload', beforeUnload);
+      window.removeEventListener('unload', unloadCallback);
+    };
+  }, []);
 
   return (
     <div className={container}>


### PR DESCRIPTION
added clean up for unfinished conversions which happens in two cases:
- users go back to previous pages by clicking breadcrumbs
- current conversion fails at some step. All data created in previous steps will be deleted