### PR TITLE
fixed a bug with incorrect checking of .dwg extension

### DIFF
--- a/src/common/store/review-manifest.store.js
+++ b/src/common/store/review-manifest.store.js
@@ -123,7 +123,7 @@ export async function createPackageWithJson(originalPackage, json) {
 
   for (let i = 0; i < entries.length; i++) {
     const file = entries[i];
-    if (file.filename.endsWith('.dwg')) {
+    if (file.filename.toLowerCase().endsWith('.dwg')) {
       const data = await file.getData(new zip.BlobWriter());
       await writer.add(file.filename, new zip.BlobReader(data));
     }


### PR DESCRIPTION
previously:
file extension was checked like file.filename.endsWith('.dwg')
the bug was that uppercase filenames like *.DWG were ignored

now:
made it case insensitive