### PR TITLE
fixed a bug with download diagnostics button

### DIFF
--- a/src/pages/conversion/conversion-content.js
+++ b/src/pages/conversion/conversion-content.js
@@ -37,7 +37,7 @@ const ConversionContent = () => {
               <LinkText href={diagnosticDocsUrl} />
             ]} />
           </div>
-          <a href={diagnosticPackageLocation} download>
+          <a href={diagnosticPackageLocation} download target='_blank' rel='noreferrer'>
             <PrimaryButton disabled={!diagnosticPackageLocation}>
               {t('download')}
             </PrimaryButton>

--- a/src/pages/conversion/index.js
+++ b/src/pages/conversion/index.js
@@ -16,7 +16,7 @@ const unloadCallback = () => {
 };
 const beforeUnload = (e) => {
   e.preventDefault();
-  return true;
+  return (e.returnValue = '');
 };
 
 const conversionStoreSelector = (s) => [


### PR DESCRIPTION
this download diagnostics button interferes with the two listeners that we have:

window.addEventListener('beforeunload', beforeUnload);
window.addEventListener('unload', unloadCallback);

so that when users click on "Download" button, it also triggers "Are you sure you want to leave?" popup.
Adding target=_blank here prevents the popup.