### PR TITLE
fixed a bug with cached levels

### DIFF
--- a/src/common/store/layers.store.js
+++ b/src/common/store/layers.store.js
@@ -19,7 +19,6 @@ export const useLayersStore = create(
     addPolygonLayers: (polygonLayers) => set((state) => ({
       polygonLayers: state.polygonLayers.concat(truncateCoordinates(polygonLayers)),
     })),
-    dwgLayers: {},
     addDwgLayers: (dwgLayers, fileName) => set((state) => ({
       dwgLayers: {
         ...state.dwgLayers,
@@ -245,6 +244,7 @@ export function checkIfLayersValid(layers) {
 
 export function getDefaultState() {
   return {
+    dwgLayers: {},
     layerNames: [],
     polygonLayers: [],
     polygonLayerNames: [],

--- a/src/common/store/layers.store.test.js
+++ b/src/common/store/layers.store.test.js
@@ -26,6 +26,7 @@ describe('layers store', () => {
 
   it('should return default state', () => {
     expect(getDefaultState()).toEqual({
+      dwgLayers: {},
       layerNames: [],
       polygonLayers: [],
       polygonLayerNames: [],


### PR DESCRIPTION
because dwgLayers prop was not part of reset function, sometimes it was not cleared properly and layers were mixed up