### PR TITLE
change deployment to release branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
-# This workflow builds current main and pushes it to gh-pages branch.
+# This workflow builds release branch and pushes it to gh-pages branch.
 
 name: Build for Deployment
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "release" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Changing deploy job so that it deploys to github pages on pushes/merges to "release branch".
Merges to main branch does not deploy anymore.