### PR TITLE
Users/v pnizetic/cleanup enhancements

### DIFF
--- a/src/common/api/api.test.js
+++ b/src/common/api/api.test.js
@@ -12,7 +12,7 @@ describe('api', () => {
   it('should call uploadFile request', () => {
     uploadPackage('myFile');
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://eu.atlas.microsoft.com/manifest?api-version=2.0&subscription-key=subKeeeeeeey',
+      'https://eu.atlas.microsoft.com/manifest?api-version=2.0&subscription-key=subKeeeeeeey&placespreview=false',
       { body: 'myFile', headers: { 'Content-Type': 'application/zip' }, method: 'POST' }
     );
   });

--- a/src/common/api/api.test.js
+++ b/src/common/api/api.test.js
@@ -1,5 +1,5 @@
-import { fetchAddress, fetchFromLocation, uploadFile, deleteFromLocation } from './index';
 import { useUserStore } from '../store';
+import { deleteFromLocation, fetchAddress, fetchFromLocation, uploadPackage } from './index';
 
 describe('api', () => {
   beforeEach(() => {
@@ -10,7 +10,7 @@ describe('api', () => {
   });
 
   it('should call uploadFile request', () => {
-    uploadFile('myFile');
+    uploadPackage('myFile');
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/manifest?api-version=2.0&subscription-key=subKeeeeeeey',
       { body: 'myFile', headers: { 'Content-Type': 'application/zip' }, method: 'POST' }

--- a/src/common/api/api.test.js
+++ b/src/common/api/api.test.js
@@ -12,7 +12,7 @@ describe('api', () => {
   it('should call uploadFile request', () => {
     uploadPackage('myFile');
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://eu.atlas.microsoft.com/manifest?api-version=2.0&subscription-key=subKeeeeeeey&placespreview=false',
+      'https://eu.atlas.microsoft.com/manifest?api-version=2.0&subscription-key=subKeeeeeeey',
       { body: 'myFile', headers: { 'Content-Type': 'application/zip' }, method: 'POST' }
     );
   });

--- a/src/common/api/api.test.js
+++ b/src/common/api/api.test.js
@@ -1,5 +1,5 @@
 import { useUserStore } from '../store';
-import { deleteFromLocation, fetchAddress, fetchFromLocation, uploadPackage } from './index';
+import { deleteFromLocation, fetchAddress, fetchFromLocation, uploadManifestPackage } from './index';
 
 describe('api', () => {
   beforeEach(() => {
@@ -10,7 +10,7 @@ describe('api', () => {
   });
 
   it('should call uploadFile request', () => {
-    uploadPackage('myFile');
+    uploadManifestPackage('myFile');
     expect(global.fetch).toHaveBeenCalledWith(
       'https://eu.atlas.microsoft.com/manifest?api-version=2.0&subscription-key=subKeeeeeeey',
       { body: 'myFile', headers: { 'Content-Type': 'application/zip' }, method: 'POST' }

--- a/src/common/api/conversion.js
+++ b/src/common/api/conversion.js
@@ -1,6 +1,4 @@
-import { PLACES_PREVIEW } from 'common/constants';
 import { getEnvs } from 'common/functions';
-import { getFeatureFlags } from 'utils';
 import { useReviewManifestStore } from '../store/review-manifest.store';
 import { useUserStore } from '../store/user.store';
 
@@ -20,12 +18,9 @@ export const uploadConversion = (file, options = {}) => {
     ...options,
   };
   const { geography, subscriptionKey } = useUserStore.getState();
-  const { isPlacesPreview } = getFeatureFlags();
   const url = `${
     getEnvs()[geography].URL
-  }/mapData?dataFormat=${dataFormat}&api-version=${apiVersion}&subscription-key=${subscriptionKey}&description=${description}&${
-    PLACES_PREVIEW.SEARCH_PARAMETER
-  }=${isPlacesPreview}`;
+  }/mapData?dataFormat=${dataFormat}&api-version=${apiVersion}&subscription-key=${subscriptionKey}&description=${description}`;
   return fetch(url, {
     method: 'POST',
     headers: {

--- a/src/common/api/conversion.js
+++ b/src/common/api/conversion.js
@@ -1,4 +1,6 @@
+import { PLACES_PREVIEW } from 'common/constants';
 import { getEnvs } from 'common/functions';
+import { getFeatureFlags } from 'utils';
 import { useReviewManifestStore } from '../store/review-manifest.store';
 import { useUserStore } from '../store/user.store';
 
@@ -18,9 +20,12 @@ export const uploadConversion = (file, options = {}) => {
     ...options,
   };
   const { geography, subscriptionKey } = useUserStore.getState();
+  const { isPlacesPreview } = getFeatureFlags();
   const url = `${
     getEnvs()[geography].URL
-  }/mapData?dataFormat=${dataFormat}&api-version=${apiVersion}&subscription-key=${subscriptionKey}&description=${description}`;
+  }/mapData?dataFormat=${dataFormat}&api-version=${apiVersion}&subscription-key=${subscriptionKey}&description=${description}&${
+    PLACES_PREVIEW.SEARCH_PARAMETER
+  }=${isPlacesPreview}`;
   return fetch(url, {
     method: 'POST',
     headers: {

--- a/src/common/api/conversion.test.js
+++ b/src/common/api/conversion.test.js
@@ -1,4 +1,4 @@
-import { uploadConversion, startConversion, startDataset, startTileset } from './conversion';
+import { startConversion, startDataset, startTileset, uploadConversion } from './conversion';
 
 jest.mock('../store/user.store', () => ({
   useUserStore: {
@@ -13,7 +13,7 @@ describe('conversion api', () => {
   it('should call uploadConversion request', () => {
     uploadConversion('myFile');
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://eu.atlas.microsoft.com/mapData?dataFormat=dwgzippackage&api-version=2.0&subscription-key=subKeeeeeeey&description=',
+      'https://eu.atlas.microsoft.com/mapData?dataFormat=dwgzippackage&api-version=2.0&subscription-key=subKeeeeeeey&description=&placespreview=false',
       { body: 'myFile', headers: { 'Content-Type': 'application/octet-stream' }, method: 'POST' }
     );
   });

--- a/src/common/api/conversion.test.js
+++ b/src/common/api/conversion.test.js
@@ -13,7 +13,7 @@ describe('conversion api', () => {
   it('should call uploadConversion request', () => {
     uploadConversion('myFile');
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://eu.atlas.microsoft.com/mapData?dataFormat=dwgzippackage&api-version=2.0&subscription-key=subKeeeeeeey&description=&placespreview=false',
+      'https://eu.atlas.microsoft.com/mapData?dataFormat=dwgzippackage&api-version=2.0&subscription-key=subKeeeeeeey&description=',
       { body: 'myFile', headers: { 'Content-Type': 'application/octet-stream' }, method: 'POST' }
     );
   });

--- a/src/common/api/conversions.js
+++ b/src/common/api/conversions.js
@@ -1,6 +1,6 @@
 import { PLACES_PREVIEW } from 'common/constants';
 import { getEnvs } from 'common/functions';
-import { deletePackage } from '.';
+import { deleteManifestPackage } from '.';
 import { useUserStore } from '../store/user.store';
 
 const uploadApiVersion = '2.0';
@@ -89,7 +89,7 @@ export const clearCloudStorageData = async () => {
       .map(conversion => conversion.conversionId);
 
     return await Promise.allSettled([
-      deletePackage(),
+      deleteManifestPackage(),
       ...uploadIDs.map(deleteUploads),
       ...conversionIDs.map(deleteConversion),
     ]);

--- a/src/common/api/conversions.js
+++ b/src/common/api/conversions.js
@@ -1,6 +1,6 @@
 import { PLACES_PREVIEW } from 'common/constants';
 import { getEnvs } from 'common/functions';
-import dayjs from 'dayjs';
+import { deletePackage } from '.';
 import { useUserStore } from '../store/user.store';
 
 const uploadApiVersion = '2.0';
@@ -81,18 +81,18 @@ export const clearCloudStorageData = async () => {
     const [uploads, conversions] = await Promise.all(responses.map(res => res.json()));
 
     const uploadIDs = uploads.mapDataList
-      .filter(upload => {
-        const updatedAt = dayjs(upload.updated);
-        const isOldEnough = dayjs().diff(updatedAt, PLACES_PREVIEW.STORAGE_RETENTION, true) > 1;
-        return upload.description === PLACES_PREVIEW.DESCRIPTION && isOldEnough;
-      })
+      .filter(upload => upload.description === PLACES_PREVIEW.DESCRIPTION)
       .map(upload => upload.udid);
 
     const conversionIDs = conversions.conversions
       .filter(conversion => uploadIDs.includes(conversion.udid))
       .map(conversion => conversion.conversionId);
 
-    await Promise.all([...uploadIDs.map(deleteUploads), ...conversionIDs.map(deleteConversion)]);
+    return await Promise.allSettled([
+      deletePackage(),
+      ...uploadIDs.map(deleteUploads),
+      ...conversionIDs.map(deleteConversion),
+    ]);
   } catch (e) {
     console.log('Error running automatic storage cleanup');
     console.log(e);

--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -28,7 +28,7 @@ export const uploadPackage = file => {
 
 export const deletePackage = () => {
   const { geography, subscriptionKey } = useUserStore.getState();
-  fetch(`${getEnvs()[geography].URL}/manifest&subscription-key=${subscriptionKey}`, {
+  fetch(`${getEnvs()[geography].URL}/manifest?api-version=2.0&subscription-key=${subscriptionKey}`, {
     method: 'DELETE',
   });
 };

--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -1,11 +1,21 @@
 // The following API is designed to be used only by the onboarding tool and is not supported for any other use.
 import { getEnvs } from 'common/functions';
+import { getFeatureFlags } from 'utils';
+import { HTTP_STATUS_CODE, PLACES_PREVIEW } from '../constants';
 import { useUserStore } from '../store/user.store';
-import { HTTP_STATUS_CODE } from '../constants';
 
-export const uploadFile = file => {
+export const uploadPackage = file => {
   const { geography, subscriptionKey } = useUserStore.getState();
-  const url = `${getEnvs()[geography].URL}/manifest?api-version=2.0&subscription-key=${subscriptionKey}`;
+
+  const { isPlacesPreview } = getFeatureFlags();
+
+  const queryParams = new URLSearchParams({
+    'api-version': '2.0',
+    'subscription-key': subscriptionKey,
+    [PLACES_PREVIEW.SEARCH_PARAMETER]: isPlacesPreview,
+  });
+
+  const url = `${getEnvs()[geography].URL}/manifest?${queryParams.toString()}`;
 
   return fetch(url, {
     method: 'POST',
@@ -13,6 +23,13 @@ export const uploadFile = file => {
       'Content-Type': 'application/zip',
     },
     body: file,
+  });
+};
+
+export const deletePackage = () => {
+  const { geography, subscriptionKey } = useUserStore.getState();
+  fetch(`${getEnvs()[geography].URL}/manifest&subscription-key=${subscriptionKey}`, {
+    method: 'DELETE',
   });
 };
 

--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -9,11 +9,16 @@ export const uploadPackage = file => {
 
   const { isPlacesPreview } = getFeatureFlags();
 
-  const queryParams = new URLSearchParams({
+  const params = {
     'api-version': '2.0',
     'subscription-key': subscriptionKey,
-    [PLACES_PREVIEW.SEARCH_PARAMETER]: isPlacesPreview,
-  });
+  };
+
+  if (isPlacesPreview) {
+    params[PLACES_PREVIEW.SEARCH_PARAMETER] = true;
+  }
+
+  const queryParams = new URLSearchParams(params);
 
   const url = `${getEnvs()[geography].URL}/manifest?${queryParams.toString()}`;
 

--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -31,7 +31,7 @@ export const uploadManifestPackage = file => {
   });
 };
 
-export const deletePackage = () => {
+export const deleteManifestPackage = () => {
   const { geography, subscriptionKey } = useUserStore.getState();
   fetch(`${getEnvs()[geography].URL}/manifest?api-version=2.0&subscription-key=${subscriptionKey}`, {
     method: 'DELETE',

--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -4,7 +4,7 @@ import { getFeatureFlags } from 'utils';
 import { HTTP_STATUS_CODE, PLACES_PREVIEW } from '../constants';
 import { useUserStore } from '../store/user.store';
 
-export const uploadPackage = file => {
+export const uploadManifestPackage = file => {
   const { geography, subscriptionKey } = useUserStore.getState();
 
   const { isPlacesPreview } = getFeatureFlags();

--- a/src/common/store/response.store.js
+++ b/src/common/store/response.store.js
@@ -1,4 +1,4 @@
-import { deleteFromLocation, fetchFromLocation, fetchWithRetries, uploadFile } from 'common/api';
+import { deleteFromLocation, fetchFromLocation, fetchWithRetries, uploadPackage } from 'common/api';
 import { clearCloudStorageData } from 'common/api/conversions';
 import { HTTP_STATUS_CODE, PLACES_PREVIEW } from 'common/constants';
 import i18next from 'common/translations/i18n';
@@ -43,21 +43,22 @@ export const useResponseStore = createWithEqualityFn(
         errorMessage: '',
       });
     },
-    uploadFile: file => {
+    uploadFile: async file => {
       const { isPlacesPreview } = getFeatureFlags();
-      if (isPlacesPreview) {
-        clearCloudStorageData();
-      }
 
       set(() => ({
         errorMessage: '',
         lroStatus: LRO_STATUS.UPLOADING,
       }));
 
+      if (isPlacesPreview) {
+        await clearCloudStorageData();
+      }
+
       useReviewManifestStore.getState().setOriginalPackage(file);
 
       repackPackage(file).then(repackedFile =>
-        uploadFile(repackedFile)
+        uploadPackage(repackedFile)
           .then(async r => {
             if (r.status !== HTTP_STATUS_CODE.ACCEPTED) {
               const data = await r.json();

--- a/src/common/store/response.store.js
+++ b/src/common/store/response.store.js
@@ -1,4 +1,4 @@
-import { deleteFromLocation, fetchFromLocation, fetchWithRetries, uploadPackage } from 'common/api';
+import { deleteFromLocation, fetchFromLocation, fetchWithRetries, uploadManifestPackage } from 'common/api';
 import { clearCloudStorageData } from 'common/api/conversions';
 import { HTTP_STATUS_CODE, PLACES_PREVIEW } from 'common/constants';
 import i18next from 'common/translations/i18n';
@@ -58,7 +58,7 @@ export const useResponseStore = createWithEqualityFn(
       useReviewManifestStore.getState().setOriginalPackage(file);
 
       repackPackage(file).then(repackedFile =>
-        uploadPackage(repackedFile)
+        uploadManifestPackage(repackedFile)
           .then(async r => {
             if (r.status !== HTTP_STATUS_CODE.ACCEPTED) {
               const data = await r.json();

--- a/src/common/store/review-manifest.store.js
+++ b/src/common/store/review-manifest.store.js
@@ -247,7 +247,8 @@ export async function repackPackage(originalPackage) {
     for (let i = 0; i < entries.length; i++) {
       const file = entries[i];
       const fileName = file.filename.toLowerCase();
-      if (!isHiddenFile(fileName) && fileName.endsWith('.dwg')) {
+      // File name is absolute path in the zip root, that is why we are using .endsWith()
+      if (!isHiddenFile(fileName) && (fileName.endsWith('.dwg') || fileName.endsWith('manifest.json'))) {
         const data = await file.getData(new zip.BlobWriter());
         await writer.add(file.filename, new zip.BlobReader(data));
       }

--- a/src/pages/conversion/clear-previous-conversions.js
+++ b/src/pages/conversion/clear-previous-conversions.js
@@ -1,0 +1,26 @@
+import { DefaultButton, Spinner, SpinnerSize } from '@fluentui/react';
+import { clearCloudStorageData } from 'common/api/conversions';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { actionButtonsRight } from './imdf-conversion.style';
+import { logsButton } from './style';
+
+export const ClearPreviousConversions = () => {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    setLoading(true);
+    await clearCloudStorageData();
+    setLoading(false);
+    toast.success('Previous conversions deleted successfully');
+  };
+
+  return (
+    <div className={actionButtonsRight}>
+      {loading && <Spinner size={SpinnerSize.medium} />}
+      <DefaultButton className={logsButton} onClick={handleClick} disabled={loading}>
+        Delete Previous Conversions
+      </DefaultButton>
+    </div>
+  );
+};

--- a/src/pages/conversion/imdf-conversion.js
+++ b/src/pages/conversion/imdf-conversion.js
@@ -7,8 +7,9 @@ import { conversionStatuses, useIMDFConversionStatus } from 'common/store/conver
 import FillScreenContainer from 'components/fill-screen-container';
 import { useAlert, useCustomNavigate } from 'hooks';
 import { useTranslation } from 'react-i18next';
+import { ClearPreviousConversions } from './clear-previous-conversions';
 import { DownloadIMDF } from './download-imdf';
-import { actionButtonsContainer, messageWrapper } from './imdf-conversion.style';
+import { actionButtonsLeft, actionButtonsWrapper, messageWrapper } from './imdf-conversion.style';
 import { ImdfDiagnostics } from './imdf-diagnostics';
 import PlacesPreviewMap from './places-preview-map';
 import StepButton from './step-button';
@@ -18,7 +19,7 @@ const ImdfConversion = () => {
   const { t } = useTranslation();
   const navigate = useCustomNavigate();
 
-const [uploadStartTime, conversionEndTime, setStep, selectedStep, imdfPackageLocation, diagnosticPackageLocation] =
+  const [uploadStartTime, conversionEndTime, setStep, selectedStep, imdfPackageLocation, diagnosticPackageLocation] =
     useConversionStore(s => [
       s.uploadStartTime,
       s.conversionEndTime,
@@ -72,11 +73,14 @@ const [uploadStartTime, conversionEndTime, setStep, selectedStep, imdfPackageLoc
                 </MessageBar>
               </div>
             ))}
-            <div className={actionButtonsContainer}>
-              {imdfConversionStatus === conversionStatuses.finishedSuccessfully && (
-                <DownloadIMDF link={imdfPackageLocation} />
-              )}
-              <ImdfDiagnostics link={diagnosticPackageLocation} />
+            <div className={actionButtonsWrapper}>
+              <div className={actionButtonsLeft}>
+                {imdfConversionStatus === conversionStatuses.finishedSuccessfully && (
+                  <DownloadIMDF link={imdfPackageLocation} />
+                )}
+                <ImdfDiagnostics link={diagnosticPackageLocation} />
+              </div>
+              <ClearPreviousConversions />
             </div>
             {imdfConversionStatus === conversionStatuses.finishedSuccessfully && (
               <FillScreenContainer offsetBottom={110}>

--- a/src/pages/conversion/imdf-conversion.style.js
+++ b/src/pages/conversion/imdf-conversion.style.js
@@ -1,8 +1,18 @@
 import { css } from '@emotion/css';
 
-export const actionButtonsContainer = css`
+export const actionButtonsWrapper = css`
   display: flex;
   gap: 1rem;
+  justify-content: space-between;
+`;
+
+export const actionButtonsLeft = css`
+  display: flex;
+  gap: 1rem;
+`;
+
+export const actionButtonsRight = css`
+  ${actionButtonsLeft}
 `;
 
 export const messageWrapper = css`

--- a/src/pages/create-manifest/create-manifest.test.js
+++ b/src/pages/create-manifest/create-manifest.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { uploadFile } from 'common/api';
+import { uploadPackage } from 'common/api';
 import { useResponseStore } from 'common/store';
 import flushPromises from 'flush-promises';
 import CreateManifestPage, { TEST_ID } from './create-manifest';
@@ -24,7 +24,7 @@ describe('CreateManifestPage', () => {
   const uploadFileSpy = jest.spyOn(state, 'uploadFile');
 
   beforeEach(() => {
-    uploadFile.mockReturnValue(Promise.resolve({}));
+    uploadPackage.mockReturnValue(Promise.resolve({}));
     file = {
       name: 'my zip archive.zip',
       size: 1024 * 1024 * 10,

--- a/src/pages/create-manifest/create-manifest.test.js
+++ b/src/pages/create-manifest/create-manifest.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { uploadPackage } from 'common/api';
+import { uploadManifestPackage } from 'common/api';
 import { useResponseStore } from 'common/store';
 import flushPromises from 'flush-promises';
 import CreateManifestPage, { TEST_ID } from './create-manifest';
@@ -15,7 +15,7 @@ jest.mock('react-router-dom', () => ({
 }));
 jest.mock('common/api', () => ({
   ...jest.requireActual('common/api'),
-  uploadPackage: jest.fn(),
+  uploadManifestPackage: jest.fn(),
 }));
 
 describe('CreateManifestPage', () => {
@@ -24,7 +24,7 @@ describe('CreateManifestPage', () => {
   const uploadFileSpy = jest.spyOn(state, 'uploadFile');
 
   beforeEach(() => {
-    uploadPackage.mockReturnValue(Promise.resolve({}));
+    uploadManifestPackage.mockReturnValue(Promise.resolve({}));
     file = {
       name: 'my zip archive.zip',
       size: 1024 * 1024 * 10,

--- a/src/pages/create-manifest/create-manifest.test.js
+++ b/src/pages/create-manifest/create-manifest.test.js
@@ -15,7 +15,7 @@ jest.mock('react-router-dom', () => ({
 }));
 jest.mock('common/api', () => ({
   ...jest.requireActual('common/api'),
-  uploadFile: jest.fn(),
+  uploadPackage: jest.fn(),
 }));
 
 describe('CreateManifestPage', () => {


### PR DESCRIPTION
Auto cleanup improvements:
- Added manifest delete
- Removed retention; all resources are always deleted
- It is now synchronous and it happens before the upload 

Manual cleanup. Added button after the conversion for manual cleanup (triggers the same cleanup flow)

Added url parameters to `/manifest` and `/mapData` endpoints. Now they have `placespreview=true/false`