### PR TITLE
Undo Feature Implemented for Units

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
         "react-i18next": "^13.5.0",
+        "react-icons": "^5.3.0",
         "react-id-generator": "^3.0.2",
         "react-json-view": "^1.21.3",
         "react-router-dom": "^6.20.0",
@@ -24595,6 +24596,14 @@
         }
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-id-generator": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/react-id-generator/-/react-id-generator-3.0.2.tgz",
@@ -48229,6 +48238,12 @@
         "@babel/runtime": "^7.22.5",
         "html-parse-stringify": "^3.0.1"
       }
+    },
+    "react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "requires": {}
     },
     "react-id-generator": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
     "react-i18next": "^13.5.0",
+    "react-icons": "^5.3.0",
     "react-id-generator": "^3.0.2",
     "react-json-view": "^1.21.3",
     "react-router-dom": "^6.20.0",

--- a/src/pages/conversion/places-preview-map/indes.style.js
+++ b/src/pages/conversion/places-preview-map/indes.style.js
@@ -36,3 +36,44 @@ export const toolbar = css `
   pointerEvents: none
 `;
 
+export const buttonStyle = css `
+  color: #323130;
+  fill: #323130;
+  background-color: #fff;
+  box-shadow: rgba(0, 0, 0, 0.16) 0 0 4px;
+  background-size: 12px 12px;
+  position: relative;
+  user-select: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-collapse: collapse;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 10px;
+  text-align: center;
+  cursor: pointer;
+  line-height: 32px;
+  background-position: center center;
+  background-repeat: no-repeat;
+  overflow: hidden;
+
+  &:hover {
+    color: #31acce;
+  }
+
+  &:disabled,
+  buttonStyle[disabled]{
+  background-color: #e5e5e5;
+  color: #6c757d;
+  cursor: not-allowed;
+  }
+`;
+
+export const idk = css `
+  position: absolute;
+  right: 1%;
+  bottom: 20%;
+  z-index: 2;
+`;
+


### PR DESCRIPTION
The undo feature appears to be greyed out with the cursor being set to 'not allowed' when it is no longer possible to do any undo-ing. If there are possible states to go back to, hitting the undo button will retrieve the last state of the map.